### PR TITLE
Feat: Test-Splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,8 @@ executors:
           POSTGRES_DB: circle_test
 
 commands:
-  setup:
+  install-deps:
     steps:
-      - checkout
       - python/install-packages:
           pkg-manager: pipenv
           # include installing dev dependencies
@@ -33,10 +32,11 @@ jobs:
   lint:
     executor: python3_10
     steps:
-      - setup
+      - checkout
+      - install-deps
       - run:
           name: Lint
-          command: pipenv run lint --check
+          command: pipenv run black . --check
   test: # this can be any name you choose
     parameters:
       split:
@@ -45,7 +45,8 @@ jobs:
     parallelism: << parameters.split >>
     executor: python3_10-postgres9_6
     steps:
-      - setup
+      - checkout
+      - install-deps
       - run:
           name: Run tests
           # alternatively, run `python -m pytest` if you are running vanilla pytest
@@ -54,30 +55,33 @@ jobs:
             TESTFILES=$(circleci tests glob "*/tests/*.py" | sed 's/\S\+__init__.py//g')
             echo $TESTFILES | tr ' ' '\n' | sort | uniq > test_files.txt
             TESTFILES=$(circleci tests split --split-by=timings test_files.txt | tr "/" "." | sed 's/\.py//g')
-            
-            echo "Debug: ${TESTFILES}"
-            
-            pipenv run test_coverage --parallel-mode --failfast $TESTFILES
-            # generates coverage.xml
-            pipenv run coverage xml
+            pipenv run coverage run --source='.' --parallel-mode \
+              manage.py test --failfast $TESTFILES
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: test-results
           destination: tr1
+      # save coverage file to workspace
       - persist_to_workspace:
           root: ~/project
           paths:
-            - .
-  combine_coverage:
+            - .coverage*
+  fan-in_coverage:
     executor: python3_10
     steps:
-      - setup
+      - checkout
+      - install-deps
       - attach_workspace:
-          at: /tmp/workspace
+          at: ~/project
+      - run:
+          name: Debug
+          command: ls -a .coverage*
       - run:
           name: Combine coverage reports (fan-in)
-          command: pipenv run coverage combine
+          command: |
+            pipenv run coverage combine
+            pipenv run coverage xml
       - codecov/upload
 
 workflows:
@@ -85,7 +89,7 @@ workflows:
     jobs:
       - lint
       - test
-      - combine_coverage:
+      - fan-in_coverage:
           requires:
             - test
   nightly:
@@ -99,6 +103,6 @@ workflows:
     jobs:
       - lint
       - test
-      - combine_coverage:
+      - fan-in_coverage:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,16 @@ version: 2.1
 
 orbs:
   python: circleci/python@1.5.0
-  # heroku: circleci/heroku@1.2.6
   codecov: codecov/codecov@3.2.2
+
+commands:
+  setup:
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pipenv
+          # include installing dev dependencies
+          args: '--dev'
 
 jobs:
   build_and_test: # this can be any name you choose
@@ -16,11 +24,7 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_DB: circle_test
     steps:
-      - checkout
-      - python/install-packages:
-          pkg-manager: pipenv
-          # include installing dev dependencies
-          args: '--dev'
+      - setup
       - run:
           name: Lint
           command: pipenv run lint --check
@@ -31,7 +35,6 @@ jobs:
             pipenv run test_coverage
             # generates coverage.xml
             pipenv run coverage xml
-      - codecov/upload
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -41,29 +44,22 @@ jobs:
           root: ~/project
           paths:
             - .
- 
-  deploy: # this can be any name you choose
+  combine_coverage:
     docker:
       - image: cimg/python:3.10.1
     steps:
+      - setup
       - attach_workspace:
-          at: ~/project
-      - heroku/deploy-via-git: 
-          force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
+          at: /tmp/workspace
+      - codecov/upload
 
 workflows:
   on_commit:
     jobs:
       - build_and_test
-      # Follow instructions here to authenticate git for Heroku: https://devcenter.heroku.com/articles/git#http-git-authentication
-      # The following code may be uncommented, onnce HEROKU_API_KEY & HEROKU_APP_NAME environemnt variables are present
-      # Read more: https://circleci.com/docs/2.0/env-vars/
-      # - deploy:
-      #     requires:
-      #       - build_and_test # only deploy if the build_and_test job has completed
-      #     filters:
-      #       branches:
-      #         only: master # only deploy when on main/master
+      - combine_coverage:
+          requires:
+            - build_and_test
   nightly:
     triggers:
       - schedule:
@@ -74,12 +70,6 @@ workflows:
                 - master
     jobs:
       - build_and_test
-      # Follow instructions here to authenticate git for Heroku: https://devcenter.heroku.com/articles/git#http-git-authentication
-      # The following code may be uncommented, onnce HEROKU_API_KEY & HEROKU_APP_NAME environemnt variables are present
-      # Read more: https://circleci.com/docs/2.0/env-vars/
-      # - deploy:
-      #     requires:
-      #       - build_and_test # only deploy if the build_and_test job has completed
-      #     filters:
-      #       branches:
-      #         only: master # only deploy when on main/master
+      - combine_coverage:
+          requires:
+            - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,22 @@ orbs:
   python: circleci/python@1.5.0
   codecov: codecov/codecov@3.2.2
 
+executors:
+  python3_10:
+    resource_class: small
+    docker:
+      - image: cimg/python:3.10.1
+  python3_10-postgres9_6:
+    resource_class: medium
+    docker:
+      - image: cimg/python:3.10.1
+        environment:
+          DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
+      - image: circleci/postgres:9.6.2
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
+
 commands:
   setup:
     steps:
@@ -14,25 +30,27 @@ commands:
           args: '--dev'
 
 jobs:
-  build_and_test: # this can be any name you choose
-    docker:
-      - image: cimg/python:3.10.1
-        environment:
-          DATABASE_URL: postgresql://root@localhost/circle_test?sslmode=disable
-      - image: circleci/postgres:9.6.2
-        environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: circle_test
+  lint:
+    executor: python3_10
     steps:
       - setup
       - run:
           name: Lint
           command: pipenv run lint --check
+  test: # this can be any name you choose
+    parameters:
+      split:
+        type: integer
+        default: 2
+    parallelism: << parameters.split >>
+    executor: python3_10-postgres9_6
+    steps:
+      - setup
       - run:
           name: Run tests
           # alternatively, run `python -m pytest` if you are running vanilla pytest
           command: |
-            pipenv run test_coverage
+            pipenv run test_coverage --parallel-mode
             # generates coverage.xml
             pipenv run coverage xml
       - store_test_results:
@@ -45,22 +63,24 @@ jobs:
           paths:
             - .
   combine_coverage:
-    resource_class: small
-    docker:
-      - image: cimg/python:3.10.1
+    executor: python3_10
     steps:
       - setup
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Combine coverage reports (fan-in)
+          command: pipenv run coverage combine
       - codecov/upload
 
 workflows:
   on_commit:
     jobs:
-      - build_and_test
+      - lint
+      - test
       - combine_coverage:
           requires:
-            - build_and_test
+            - test
   nightly:
     triggers:
       - schedule:
@@ -70,7 +90,8 @@ workflows:
               only:
                 - master
     jobs:
-      - build_and_test
+      - lint
+      - test
       - combine_coverage:
           requires:
-            - build_and_test
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,11 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: Debug
-          command: ls -a .coverage*
-      - run:
           name: Combine coverage reports (fan-in)
+          command: pipenv run coverage combine
+      - run:
+          name: Generate coverage report in XML
           command: |
-            pipenv run coverage combine
             pipenv run coverage xml
       - codecov/upload
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
           paths:
             - .
   combine_coverage:
+    resource_class: small
     docker:
       - image: cimg/python:3.10.1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,14 @@ jobs:
           name: Run tests
           # alternatively, run `python -m pytest` if you are running vanilla pytest
           command: |
-            pipenv run test_coverage --parallel-mode
+            # get test files while ignoring __init__ files
+            TESTFILES=$(circleci tests glob "*/tests/*.py" | sed 's/\S\+__init__.py//g')
+            echo $TESTFILES | tr ' ' '\n' | sort | uniq > test_files.txt
+            TESTFILES=$(circleci tests split --split-by=timings test_files.txt | tr "/" "." | sed 's/\.py//g')
+            
+            echo "Debug: ${TESTFILES}"
+            
+            pipenv run test_coverage --parallel-mode --failfast $TESTFILES
             # generates coverage.xml
             pipenv run coverage xml
       - store_test_results:

--- a/Pipfile
+++ b/Pipfile
@@ -3,11 +3,6 @@ url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-[scripts]
-lint = "black ."
-test = "python manage.py test"
-test_coverage = "coverage run --source='.' manage.py test"
-
 [packages]
 dj-database-url = "*"
 django = "==3.1.1"


### PR DESCRIPTION
This PR utilizes the documented steps to split tests for Django on CircleCI:
https://circleci.com/docs/2.0/parallelism-faster-jobs/#using-test-splitting-with-python-django-tests

We take advantage of the already-existing parallel-mode option enabled with coverage.py:
https://coverage.readthedocs.io/en/6.3.1/cmd.html#combining-data-files-coverage-combine